### PR TITLE
Fix failing build pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 # Global env vars (non-secret)
 env:
-  DOTNET_VERSION: "8.0.x"
+  DOTNET_VERSION: "9.0.x"
   PULUMI_STACK: "dev"
   PULUMI_WORK_DIR: "infrastructure"
 
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+          include-prerelease: true
 
       - name: Restore & Build
         run: |


### PR DESCRIPTION
Update `deploy.yml` to use .NET 9.0 SDK and include prerelease versions to resolve build failures.

The build pipeline was failing because the .csproj files target .NET 9.0, but the workflow was installing the .NET 8.0.x SDK, leading to `NETSDK1045` errors.

---

[Open in Web](https://cursor.com/agents?id=bc-87fe58de-936b-488f-8fed-3cb4cb85c640) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-87fe58de-936b-488f-8fed-3cb4cb85c640) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)