### PR TITLE
Fix GitHub Actions workflow .NET version mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 # Global env vars (non-secret)
 env:
-  DOTNET_VERSION: "8.0.x"
+  DOTNET_VERSION: "9.0.x"
   PULUMI_STACK: "dev"
   PULUMI_WORK_DIR: "infrastructure"
 

--- a/infrastructure/Infrastructure.csproj
+++ b/infrastructure/Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Fixes critical deployment pipeline failures caused by .NET version mismatch between project targets and CI/CD configuration.

## Problem

The GitHub Actions deployment workflow has been consistently failing with the following error:
```
error NETSDK1045: The current .NET SDK does not support targeting .NET 9.0. 
Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0.
```

**Root Cause Analysis:**
- All application projects target `.NET 9.0` (as documented in CLAUDE.md architecture overview)
- GitHub Actions workflow was configured to install `.NET 8.0.x`
- Infrastructure project was inconsistently targeting `.NET 8.0`

## Changes Made

### 1. Updated GitHub Actions Workflow (`.github/workflows/deploy.yml`)
- **Before:** `DOTNET_VERSION: "8.0.x"`
- **After:** `DOTNET_VERSION: "9.0.x"`

This ensures the CI/CD pipeline installs the correct .NET SDK version that matches all project targets.

### 2. Updated Infrastructure Project (`infrastructure/Infrastructure.csproj`)
- **Before:** `<TargetFramework>net8.0</TargetFramework>`
- **After:** `<TargetFramework>net9.0</TargetFramework>`

This maintains consistency across the entire solution, aligning with the documented .NET 9 architecture.

## Testing

✅ **Local Verification:**
- `dotnet restore` - ✅ All packages restored successfully
- `dotnet build -c Release --no-restore` - ✅ Build succeeded with only warnings
- `dotnet test --no-build --verbosity normal` - ✅ All 140+ unit tests pass

✅ **Expected CI/CD Impact:**
- Deployment workflow should now pass the restore and build steps
- Pulumi infrastructure deployment should proceed without .NET version conflicts

## Impact

- **Deployment Pipeline:** Fixes all recent deployment failures (runs #16543580373, #16543562695, #16542841834)
- **Development:** Maintains consistency with documented .NET 9 architecture
- **Infrastructure:** Ensures Pulumi infrastructure project uses same runtime as application

## Rollback Plan

If issues arise, this can be safely reverted by:
1. Reverting the workflow to use .NET 8.0.x
2. Downgrading all projects to target .NET 8.0

However, this would require updating the architecture documentation and potentially losing .NET 9 performance/feature benefits.

## Related Issues

Addresses deployment pipeline failures that have been occurring since the solution was configured for .NET 9.0 but the CI/CD pipeline wasn't updated accordingly.

🤖 Generated with [Claude Code](https://claude.ai/code)