### PR TITLE
fix: pin Azure Search clients to the API's system-assigned identity

### DIFF
--- a/4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchClientFactory.cs
+++ b/4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchClientFactory.cs
@@ -1,5 +1,5 @@
 using Azure;
-using Azure.Identity;
+using Azure.Core;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
 using Microsoft.Extensions.Options;
@@ -12,14 +12,14 @@ namespace MotorcycleRAG.Persistence.Azure.Search;
 /// <summary>
 /// Default <see cref="ISearchClientFactory"/>. Lazily creates one
 /// <see cref="SearchClient"/> per category index and caches it for the lifetime of this
-/// factory instance. A single <see cref="DefaultAzureCredential"/> is shared across all
-/// clients (it is the documented cold-auth source and should be reused, not recreated
-/// per request).
+/// factory instance. A single <see cref="TokenCredential"/> (see <see cref="SearchCredential"/>)
+/// is shared across all clients (it is the documented cold-auth source and should be reused,
+/// not recreated per request).
 /// </summary>
 public sealed class SearchClientFactory : ISearchClientFactory
 {
     private readonly Uri _searchServiceEndpoint;
-    private readonly DefaultAzureCredential _credential;
+    private readonly TokenCredential _credential;
     private readonly SearchIndexClient _indexClient;
     private readonly Dictionary<MotorcycleCategory, SearchClient> _clientsByCategory = new();
 
@@ -44,9 +44,10 @@ public sealed class SearchClientFactory : ISearchClientFactory
         }
 
         _searchServiceEndpoint = endpoint;
-        // DefaultAzureCredential is intentionally shared (created once) — recreating it per client
+        // The credential is intentionally shared (created once) — recreating it per client
         // multiplies the cold-auth latency that is the known freeze source (plan §1 root-cause #7).
-        _credential = new DefaultAzureCredential();
+        // See SearchCredential for why this is pinned rather than a bare DefaultAzureCredential.
+        _credential = SearchCredential.Create();
         _indexClient = indexClient ?? throw new ArgumentNullException(nameof(indexClient));
     }
 

--- a/4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchCredential.cs
+++ b/4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchCredential.cs
@@ -1,0 +1,27 @@
+using Azure.Core;
+using Azure.Identity;
+
+namespace MotorcycleRAG.Persistence.Azure.Search;
+
+/// <summary>
+/// Builds the <see cref="TokenCredential"/> used by every Azure AI Search client.
+/// </summary>
+/// <remarks>
+/// The API Container App is provisioned with a combined system-assigned + user-assigned
+/// identity (<c>7-Deployment/infrastructure/Program.cs</c>): the system-assigned identity holds
+/// "Search Index Data Contributor" (<c>Program.cs:889-899</c>), while the user-assigned identity
+/// exists only for ACR pulls and has no Search RBAC. <see cref="DefaultAzureCredential"/>'s long
+/// credential chain does not guarantee which of the two managed identities its
+/// <see cref="ManagedIdentityCredential"/> leg resolves to on a resource carrying both types.
+/// An unqualified <see cref="ManagedIdentityCredential"/> reliably targets the system-assigned
+/// identity — the same construction <c>AppConfigurationExtensions.cs</c> already uses
+/// successfully against App Configuration/Key Vault in this deployment — so Search clients use
+/// that explicitly instead, falling back to <see cref="AzureCliCredential"/> for local
+/// development where no managed identity exists.
+/// </remarks>
+internal static class SearchCredential {
+    public static TokenCredential Create() =>
+        new ChainedTokenCredential(
+            new ManagedIdentityCredential(new ManagedIdentityCredentialOptions()),
+            new AzureCliCredential());
+}

--- a/4-Persistence/MotorcycleRAG.Persistence/Azure/ServiceCollectionExtensions.cs
+++ b/4-Persistence/MotorcycleRAG.Persistence/Azure/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Azure.Identity;
 using Azure.Search.Documents.Indexes;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -92,8 +91,7 @@ public static class ServiceCollectionExtensions {
         // "no singleton SearchClient bound to one index" rule).
         services.AddSingleton<SearchIndexClient>(serviceProvider => {
             var azureConfig = serviceProvider.GetRequiredService<IOptions<AzureFoundryOptions>>().Value;
-            var credential = new DefaultAzureCredential();
-            return new SearchIndexClient(new Uri(azureConfig.SearchServiceEndpoint), credential);
+            return new SearchIndexClient(new Uri(azureConfig.SearchServiceEndpoint), SearchCredential.Create());
         });
 
         // Per-index SearchClient factory (D4 category partitioning). Replaces the former

--- a/5-Test/tests/MotorcycleRAG.UnitTests/Azure/SearchCredentialTests.cs
+++ b/5-Test/tests/MotorcycleRAG.UnitTests/Azure/SearchCredentialTests.cs
@@ -1,0 +1,38 @@
+using Azure.Core;
+using Azure.Identity;
+using MotorcycleRAG.Persistence.Azure.Search;
+
+namespace MotorcycleRAG.UnitTests.Azure;
+
+/// <summary>
+/// Covers <see cref="SearchCredential"/>, the pinned credential used by every Azure AI Search
+/// client instead of a bare <see cref="DefaultAzureCredential"/> (see
+/// 6-Docs/operations/azure-search-rbac-local-dev.md for why the API Container App's combined
+/// system-assigned/user-assigned identity made <c>DefaultAzureCredential</c> unreliable here).
+/// </summary>
+public class SearchCredentialTests {
+    [Fact]
+    public void Create_ReturnsATokenCredential() {
+        var credential = SearchCredential.Create();
+
+        credential.Should().NotBeNull();
+        credential.Should().BeAssignableTo<TokenCredential>();
+    }
+
+    [Fact]
+    public void Create_ReturnsAChainedTokenCredential_NotABareDefaultAzureCredential() {
+        var credential = SearchCredential.Create();
+
+        credential.Should().BeOfType<ChainedTokenCredential>(
+            "Search clients must not fall back to DefaultAzureCredential's full chain, " +
+            "which cannot reliably disambiguate the API Container App's two managed identities");
+    }
+
+    [Fact]
+    public void Create_ReturnsANewInstanceEachCall() {
+        var first = SearchCredential.Create();
+        var second = SearchCredential.Create();
+
+        first.Should().NotBeSameAs(second, "callers are responsible for caching/reusing a single instance");
+    }
+}

--- a/6-Docs/operations/azure-search-rbac-local-dev.md
+++ b/6-Docs/operations/azure-search-rbac-local-dev.md
@@ -1,0 +1,50 @@
+# Azure AI Search RBAC — Local Dev 403 on Chunk Indexing
+
+**Component:** `MotorcycleRAG.API` — `SearchClientFactory` / `ChunkIndexingService`
+**Audience:** Developers running the API locally against `mcr-rag-dev-wcus-search`
+**Status:** Investigated 2026-07-09. Root cause confirmed. **Fix not yet applied** — requires an explicit, authorized action (RBAC mutation) that this change intentionally does not perform. See "Next step" below.
+
+---
+
+## Symptom
+
+Chunk indexing (`ChunkIndexingService.MergeOrUploadDocumentsAsync`) fails with **403 Forbidden** when the API runs locally, even though the Python local processor already uploaded `chunks.jsonl` to blob storage successfully.
+
+## Root cause (confirmed)
+
+`SearchClientFactory` (`4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchClientFactory.cs:49`) authenticates with `DefaultAzureCredential`. In local development this resolves to the developer's **Azure CLI identity** (`david_palfery@epam.com`), which currently holds only **Search Index Data Reader** on `mcr-rag-dev-wcus-search` — read-only. The app's own identity, the user-assigned managed identity `mcr-rag-dev-cus-api0689104e`, already has **Search Index Data Contributor**, but that identity is only usable when the API runs *as* the Container App in Azure.
+
+## Why "point `DefaultAzureCredential` at the app's managed identity locally" does not work
+
+A proposal was raised to fix this by setting `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` for the local API process so `DefaultAzureCredential` resolves to `mcr-rag-dev-cus-api0689104e` instead of the developer's CLI identity. This was investigated and **rejected as non-functional**, for two independent reasons:
+
+1. **The identity is a real Azure User-Assigned Managed Identity, not a service principal.** Confirmed in `7-Deployment/infrastructure/Program.cs:266` (`Pulumi.AzureNative.ManagedIdentity.UserAssignedIdentity`), assigned to the Container Apps via `SystemAssigned_UserAssigned` (`Program.cs:308-310`). Managed identities have **no client secret** — there is nothing to hand to `ClientSecretCredential`/`EnvironmentCredential` outside Azure.
+   - `DefaultAzureCredential`'s `EnvironmentCredential` only activates when `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` are accompanied by `AZURE_CLIENT_SECRET` (or a cert path). With only client ID + tenant ID set, it is skipped.
+   - `ManagedIdentityCredential` only works via the Azure Instance Metadata Service (IMDS), which exists solely on Azure-hosted compute (the Container App, a VM, App Service, etc.) — not a local dev machine. It fails locally regardless of which client ID is set.
+   - Net effect: `DefaultAzureCredential` falls through the chain to `AzureCliCredential` anyway, landing back on `david_palfery@epam.com` — **the 403 would persist**, just with a more confusing setup to debug.
+
+2. **It would violate this repo's environment-variable policy.** `6-Docs/environment-variables.md:3-7` states environment variables are *not* a general configuration mechanism here, and explicitly: *"Do not add `MCR_API_*`... environment-variable paths for .NET code... The only approved environment-variable surface is the Python local processor."* Wiring ad-hoc `AZURE_CLIENT_ID`/`AZURE_TENANT_ID` into the API's local launch profile runs against that documented rule and would need an explicit policy exception, not a quiet workaround.
+
+## Options that do work
+
+**Option A — Grant the developer's CLI identity write access (recommended, matches how `DefaultAzureCredential` actually resolves locally):**
+
+```bash
+az role assignment create \
+  --assignee david_palfery@epam.com \
+  --role "Search Index Data Contributor" \
+  --scope /subscriptions/5df33f46-892f-4dc1-9d0c-701464efd7e5/resourceGroups/mcr-rag-dev-cus-rg49bcb82b/providers/Microsoft.Search/searchServices/mcr-rag-dev-wcus-search
+```
+
+Zero code changes. Role propagation is typically 1–2 minutes; retry the upload/job afterward.
+
+**Option B — Dedicated local-dev service principal:** create a *separate* Entra app registration (not the Container App's managed identity — a real app registration with a client secret), grant it `Search Index Data Contributor`, and use it locally via `ClientSecretCredential`. This keeps the personal identity read-only but requires new-app-registration + secret-rotation overhead, and — per the policy above — would need an explicit, approved mechanism for surfacing the secret to the .NET process (not a plain `AZURE_CLIENT_SECRET` env var by default).
+
+## What this change intentionally does NOT do
+
+- **No `launchSettings.json`/env var changes were made** for the .NET API — the managed-identity-via-env-var approach doesn't fix the 403 (see above) and conflicts with `environment-variables.md`.
+- **No `az role assignment create` was executed.** Granting a role on `mcr-rag-dev-wcus-search` is a write to shared Azure RBAC state on a real subscription; it requires explicit authorization before being run, which was not obtained in this session (see `6-Docs/agent-instructions/azure-environment.md` subscription-allowlist guard rail).
+
+## Next step required
+
+A human needs to explicitly authorize **Option A** (run the `az role assignment create` above) or **Option B** (provision a dedicated service principal). This document records the investigation so that decision can be made without re-deriving the root cause.

--- a/6-Docs/operations/azure-search-rbac-local-dev.md
+++ b/6-Docs/operations/azure-search-rbac-local-dev.md
@@ -1,50 +1,55 @@
-# Azure AI Search RBAC — Local Dev 403 on Chunk Indexing
+# Azure AI Search 403 on Chunk Indexing (Job 19)
 
 **Component:** `MotorcycleRAG.API` — `SearchClientFactory` / `ChunkIndexingService`
-**Audience:** Developers running the API locally against `mcr-rag-dev-wcus-search`
-**Status:** Investigated 2026-07-09. Root cause confirmed. **Fix not yet applied** — requires an explicit, authorized action (RBAC mutation) that this change intentionally does not perform. See "Next step" below.
+**Audience:** Developers/operators of the deployed API at `motorag.api.palfery.com`
+**Status:** Root cause revised 2026-07-09 after confirming the actual request path; fix applied in code (see "Fix applied").
 
 ---
 
 ## Symptom
 
-Chunk indexing (`ChunkIndexingService.MergeOrUploadDocumentsAsync`) fails with **403 Forbidden** when the API runs locally, even though the Python local processor already uploaded `chunks.jsonl` to blob storage successfully.
+Chunk indexing (`ChunkIndexingService.MergeOrUploadDocumentsAsync`) fails with **403 Forbidden**. Confirmed request path for job 19: the Admin Desktop app uploads `chunks.jsonl` to blob storage via the **deployed API running in Azure Container Apps** (`https://motorag.api.palfery.com`, the Admin app's default `apiBaseUrl` — `1-Presentation/MotorcycleRAG.AdminDesktop/src/lib/config.ts:33`), then calls that same API to execute the Search index push. The Python local processor and a locally-run `dotnet run` API are **not** part of this path.
 
-## Root cause (confirmed)
+## Root cause
 
-`SearchClientFactory` (`4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchClientFactory.cs:49`) authenticates with `DefaultAzureCredential`. In local development this resolves to the developer's **Azure CLI identity** (`david_palfery@epam.com`), which currently holds only **Search Index Data Reader** on `mcr-rag-dev-wcus-search` — read-only. The app's own identity, the user-assigned managed identity `mcr-rag-dev-cus-api0689104e`, already has **Search Index Data Contributor**, but that identity is only usable when the API runs *as* the Container App in Azure.
+The API Container App (`apiApp`, `7-Deployment/infrastructure/Program.cs:305-330`) is provisioned with a **combined identity** — `Type = SystemAssigned_UserAssigned` (`Program.cs:308-310`):
 
-## Why "point `DefaultAzureCredential` at the app's managed identity locally" does not work
+- a **system-assigned** identity, which holds `Search Index Data Contributor` + `Reader` (`Program.cs:889-899`, scoped to `searchService.Id` — the current serverless `mcr-rag-dev-wcus-search`);
+- a separate **user-assigned** identity (`containerAppIdentity`, `Program.cs:266`), which holds only `AcrPull` (`Program.cs:926-931`) for pulling container images — **no Search RBAC at all**.
 
-A proposal was raised to fix this by setting `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` for the local API process so `DefaultAzureCredential` resolves to `mcr-rag-dev-cus-api0689104e` instead of the developer's CLI identity. This was investigated and **rejected as non-functional**, for two independent reasons:
+`SearchClientFactory` (`SearchClientFactory.cs:49`, before this fix) and the `SearchIndexClient` DI registration (`ServiceCollectionExtensions.cs:95`, before this fix) both authenticated with a bare `new DefaultAzureCredential()`. On a resource carrying two managed identities simultaneously, `DefaultAzureCredential`'s internal `ManagedIdentityCredential` leg is not guaranteed to resolve to the system-assigned identity — if it resolves to the user-assigned `containerAppIdentity` instead, that identity has zero Search permissions, producing exactly the observed 403.
 
-1. **The identity is a real Azure User-Assigned Managed Identity, not a service principal.** Confirmed in `7-Deployment/infrastructure/Program.cs:266` (`Pulumi.AzureNative.ManagedIdentity.UserAssignedIdentity`), assigned to the Container Apps via `SystemAssigned_UserAssigned` (`Program.cs:308-310`). Managed identities have **no client secret** — there is nothing to hand to `ClientSecretCredential`/`EnvironmentCredential` outside Azure.
-   - `DefaultAzureCredential`'s `EnvironmentCredential` only activates when `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` are accompanied by `AZURE_CLIENT_SECRET` (or a cert path). With only client ID + tenant ID set, it is skipped.
-   - `ManagedIdentityCredential` only works via the Azure Instance Metadata Service (IMDS), which exists solely on Azure-hosted compute (the Container App, a VM, App Service, etc.) — not a local dev machine. It fails locally regardless of which client ID is set.
-   - Net effect: `DefaultAzureCredential` falls through the chain to `AzureCliCredential` anyway, landing back on `david_palfery@epam.com` — **the 403 would persist**, just with a more confusing setup to debug.
+This is corroborated by contrast with `AppConfigurationExtensions.cs:25`, which authenticates against App Configuration/Key Vault using an **unqualified `ManagedIdentityCredential(new ManagedIdentityCredentialOptions())`** (not `DefaultAzureCredential`) — and that path works reliably in the same deployment. Search's client construction was the outlier.
 
-2. **It would violate this repo's environment-variable policy.** `6-Docs/environment-variables.md:3-7` states environment variables are *not* a general configuration mechanism here, and explicitly: *"Do not add `MCR_API_*`... environment-variable paths for .NET code... The only approved environment-variable surface is the Python local processor."* Wiring ad-hoc `AZURE_CLIENT_ID`/`AZURE_TENANT_ID` into the API's local launch profile runs against that documented rule and would need an explicit policy exception, not a quiet workaround.
+## Fix applied
 
-## Options that do work
+Added `SearchCredential` (`4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchCredential.cs`), used by both Search call sites, that pins the credential chain instead of using a bare `DefaultAzureCredential`:
 
-**Option A — Grant the developer's CLI identity write access (recommended, matches how `DefaultAzureCredential` actually resolves locally):**
-
-```bash
-az role assignment create \
-  --assignee david_palfery@epam.com \
-  --role "Search Index Data Contributor" \
-  --scope /subscriptions/5df33f46-892f-4dc1-9d0c-701464efd7e5/resourceGroups/mcr-rag-dev-cus-rg49bcb82b/providers/Microsoft.Search/searchServices/mcr-rag-dev-wcus-search
+```csharp
+new ChainedTokenCredential(
+    new ManagedIdentityCredential(new ManagedIdentityCredentialOptions()),  // matches AppConfigurationExtensions.cs's proven pattern
+    new AzureCliCredential());                                             // local dev fallback (no managed identity off-Azure)
 ```
 
-Zero code changes. Role propagation is typically 1–2 minutes; retry the upload/job afterward.
+- `SearchClientFactory.cs` — `_credential` now built via `SearchCredential.Create()`.
+- `ServiceCollectionExtensions.cs` — the `SearchIndexClient` singleton now uses `SearchCredential.Create()`.
 
-**Option B — Dedicated local-dev service principal:** create a *separate* Entra app registration (not the Container App's managed identity — a real app registration with a client secret), grant it `Search Index Data Contributor`, and use it locally via `ClientSecretCredential`. This keeps the personal identity read-only but requires new-app-registration + secret-rotation overhead, and — per the policy above — would need an explicit, approved mechanism for surfacing the secret to the .NET process (not a plain `AZURE_CLIENT_SECRET` env var by default).
+This also narrows the credential-probe surface from `DefaultAzureCredential`'s full ~9-credential chain down to 2, which should help the "cold-auth hang source" already flagged in `SearchClientFactory`'s own comments and in `6-Docs/plans/2026-07-07-chunk-upload-fix-and-serverless-search.md` (§1, root-cause #7).
 
-## What this change intentionally does NOT do
+**Caveat — not fully confirmed against live telemetry:** this diagnosis is built from static analysis of the Pulumi IaC and the working App Configuration credential pattern; the Search service does not yet have diagnostic logging wired to Log Analytics (that's tracked separately as T1/T10 in the serverless-migration plan), so the specific caller identity for job 19's failing request could not be directly confirmed from logs. If job 19 still fails after this deploys, that diagnostic gap should be closed next so the actual principal can be read directly instead of inferred.
 
-- **No `launchSettings.json`/env var changes were made** for the .NET API — the managed-identity-via-env-var approach doesn't fix the 403 (see above) and conflicts with `environment-variables.md`.
-- **No `az role assignment create` was executed.** Granting a role on `mcr-rag-dev-wcus-search` is a write to shared Azure RBAC state on a real subscription; it requires explicit authorization before being run, which was not obtained in this session (see `6-Docs/agent-instructions/azure-environment.md` subscription-allowlist guard rail).
+## Verification
 
-## Next step required
+After this ships and a new revision of the API Container App is deployed:
+1. Retry job 19 (or re-run the upload → index flow from the Admin app).
+2. If it still 403s, check whether `az search service show`/`az role assignment list --scope <searchService.Id>` still shows the role only on the system-assigned principal, and consider adding Search diagnostic logs (plan T1/T10) to capture the actual caller identity on the next failure.
 
-A human needs to explicitly authorize **Option A** (run the `az role assignment create` above) or **Option B** (provision a dedicated service principal). This document records the investigation so that decision can be made without re-deriving the root cause.
+---
+
+## Superseded analysis (kept for context — do not act on this)
+
+An earlier version of this document assumed job 19 ran against a **locally-running** API process (`dotnet run` on a developer machine) rather than the deployed Container App, and concluded the 403 was caused by the developer's Azure CLI identity (`david_palfery@epam.com`) holding only `Search Index Data Reader`. That premise was **incorrect** — job 19 ran through `motorag.api.palfery.com` (confirmed above) — so that analysis, and its proposed local-CLI-role-grant fix, do not apply to this incident. It's preserved below only because the general reasoning (why a bare managed-identity client ID/tenant ID env var can't authenticate outside Azure, and why this repo's `environment-variables.md` policy blocks ad-hoc .NET env-var auth) remains accurate for genuine local-dev scenarios, should one come up separately.
+
+- Managed identities have no client secret usable outside Azure; `ManagedIdentityCredential` requires IMDS, only present on Azure-hosted compute.
+- `6-Docs/environment-variables.md:3-7` restricts environment-variable configuration to the Python local processor only — not .NET code.
+- If a genuine local-dev-loop RBAC gap is ever found (developer running the API directly against Azure resources), the two working options are: grant the developer's CLI identity the needed role directly, or provision a dedicated service principal with a real secret for local use.


### PR DESCRIPTION
## Summary

- Job 19's 403 Forbidden on chunk indexing came from the **deployed API Container App** (`motorag.api.palfery.com`), not local dev as first assumed — the admin app uploads via that API, which then calls Azure AI Search itself.
- That Container App is provisioned with a **combined identity** (`Program.cs:308-310`, `SystemAssigned_UserAssigned`): the **system-assigned** identity holds `Search Index Data Contributor` (`Program.cs:889-899`), while a separate **user-assigned** identity (`containerAppIdentity`) exists only for ACR pulls (`Program.cs:926-931`) and has zero Search permissions.
- `SearchClientFactory` and the `SearchIndexClient` DI registration both authenticated with a bare `new DefaultAzureCredential()`, which is not guaranteed to disambiguate which of the two identities it resolves to on a combined-identity resource.
- **Fix:** added `SearchCredential` (`4-Persistence/MotorcycleRAG.Persistence/Azure/Search/SearchCredential.cs`), mirroring the credential construction `AppConfigurationExtensions.cs:25` already uses successfully against App Configuration/Key Vault in the same deployment — an explicit, unqualified `ManagedIdentityCredential` (documented by Microsoft to target the system-assigned identity), with an `AzureCliCredential` fallback for local dev. Wired both Search call sites to it.
- Corrected `6-Docs/operations/azure-search-rbac-local-dev.md`: an earlier version wrongly attributed the 403 to the developer's local Azure CLI identity (based on an incorrect assumption about which environment executed the failing request); that analysis is kept, clearly marked superseded, since it's still valid for a genuine local-dev-loop scenario.
- An independent `code-reviewer` sub-agent reviewed the change against the actual Pulumi source and Microsoft Learn documentation and returned **APPROVED**.

## Test plan

- [x] Added `5-Test/tests/MotorcycleRAG.UnitTests/Azure/SearchCredentialTests.cs` covering the new credential helper (non-null, `ChainedTokenCredential` not `DefaultAzureCredential`, fresh instance per call).
- [x] Existing `SearchClientFactoryTests.cs` unaffected — constructor signature unchanged, only the private `_credential` field's static type changed.
- [ ] **No `dotnet` SDK available in this sandbox** — could not run `dotnet build`/`dotnet test` locally; relying on CI to confirm compilation and full test suite.
- [ ] Human verification once deployed: retry job 19 (or re-run the upload → index flow from the Admin app) against the new revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
